### PR TITLE
Fixed link to the LICENSE file;

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ See also the list of [contributors](https://github.com/the-universe/Homo-Sapiens
 
 ## License
 
-This project is licensed under the Apache License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the Apache License - see the [LICENSE](LICENSE) file for details


### PR DESCRIPTION
Rather than renaming the LICENSE file to 'LICENSE.md' I chose to fix the
link to the file, as the LICENSE file is actually not a Markdown file.
